### PR TITLE
Inno Setup improvements - Separate script for languages and strings

### DIFF
--- a/installer/InstallerClean.iss
+++ b/installer/InstallerClean.iss
@@ -1,4 +1,4 @@
-﻿; InstallerClean Inno Setup script.
+; InstallerClean Inno Setup script.
 ;
 ; AppId stays constant across versions ("InstallerClean") so Windows
 ; treats every shipped version as the same product; the uninstall
@@ -11,6 +11,7 @@
 ; for ad-hoc local builds; it tracks the current shipping target so a
 ; from-source install doesn't claim an older version on the Add/Remove
 ; Programs entry.
+# include InstallerClean_Languages.iss
 [Setup]
 #ifndef AppVersion
   #define AppVersion "1.9.1"
@@ -84,32 +85,6 @@ ShowLanguageDialog=yes
 ; install's pick, so a language added in a later version becomes the default
 ; for an upgrading user whose OS matches it; the dialog still lists them all.
 UsePreviousLanguage=no
-
-[Languages]
-Name: "english"; MessagesFile: "compiler:Default.isl"
-Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
-
-; Welcome/Finished are standard Inno [Messages], overridden per language with
-; the language-name prefix. They must live here, NOT in [CustomMessages]:
-; [CustomMessages] entries are only reachable via {cm:Name} and would not
-; override the wizard's own text. Italian.isl supplies the rest of the wizard.
-[Messages]
-english.WelcomeLabel1=Welcome to InstallerClean setup
-english.WelcomeLabel2=This will install InstallerClean on your computer.
-english.FinishedHeadingLabel=Setup complete
-english.FinishedLabel=InstallerClean has been installed on your computer.
-english.ClickFinish=Click Finish to close setup.
-italian.WelcomeLabel1=Benvenuto nell'installazione di InstallerClean
-italian.WelcomeLabel2=Questo installerà InstallerClean nel computer.
-italian.FinishedHeadingLabel=Installazione completata
-italian.FinishedLabel=InstallerClean è stato installato nel computer.
-italian.ClickFinish=Per chiudere l'installazione seleziona 'Fine'.
-
-[CustomMessages]
-english.UninstallApp=Uninstall InstallerClean
-english.LaunchApp=Launch InstallerClean
-italian.UninstallApp=Disinstalla InstallerClean
-italian.LaunchApp=Esegui InstallerClean
 
 [Files]
 Source: "{#PublishDir}\self-contained\InstallerClean.exe"; DestDir: "{app}"; Flags: ignoreversion

--- a/installer/InstallerClean_Languages.iss
+++ b/installer/InstallerClean_Languages.iss
@@ -1,0 +1,28 @@
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
+
+; Welcome/Finished are standard Inno [Messages], overridden per language with
+; the language-name prefix. They must live here, NOT in [CustomMessages]:
+; [CustomMessages] entries are only reachable via {cm:Name} and would not
+; override the wizard's own text. Italian.isl supplies the rest of the wizard.
+[Messages]
+english.WelcomeLabel1=Welcome to InstallerClean setup
+english.WelcomeLabel2=This will install InstallerClean on your computer.
+english.FinishedHeadingLabel=Setup complete
+english.FinishedLabel=InstallerClean has been installed on your computer.
+english.ClickFinish=Click Finish to close setup.
+
+italian.WelcomeLabel1=Benvenuto nell'installazione di InstallerClean
+italian.WelcomeLabel2=Questo installerà InstallerClean nel computer.
+italian.FinishedHeadingLabel=Installazione completata
+italian.FinishedLabel=InstallerClean è stato installato nel computer.
+italian.ClickFinish=Per chiudere l'installazione seleziona 'Fine'.
+
+[CustomMessages]
+english.UninstallApp=Uninstall InstallerClean
+english.LaunchApp=Launch InstallerClean
+
+italian.UninstallApp=Disinstalla InstallerClean
+italian.LaunchApp=Esegui InstallerClean
+italian.NameAndVersion=%1 %2


### PR DESCRIPTION
@FarmLox 

## What this changes

Create a separate Inno Setup script that contains only languages and string definitions.
Adding custom ***NameAndVersion*** string for Italian to fix the issue regarding "versione" on top left.
This NameAndVersion string is fixed (without "versione" from Inno Setup 7.x - not version before).
The Inno Setup author confirmed that my feedfback is right ("versione" is not necessary) but apply this fix only starting from IS version 7.x.
Before IS 7,x the way to fix is adding custom string for NameAndVersion without "versione".
 
## Why

Separate handling of language and strings by main script body

