### PR TITLE
Add UninstallDisplayName to InstallerClean setup

### DIFF
--- a/installer/InstallerClean.iss
+++ b/installer/InstallerClean.iss
@@ -67,6 +67,7 @@ VersionInfoCopyright=(c) {#CurrentYear} {#MyCompany}
 VersionInfoDescription=InstallerClean Setup
 DefaultDirName={autopf}\InstallerClean
 DefaultGroupName=InstallerClean
+UninstallDisplayName=InstallerClean
 UninstallDisplayIcon={app}\InstallerClean.exe
 OutputDir={#PublishDir}
 ; The version is part of the download's name from 2.2.0 on. A setup exe sitting


### PR DESCRIPTION
@FarmLox 

## What this changes

In Windows program list remove version after program name (versionis already available in Version columnb)

## Why

To have program name without info about version.
winget use program name to show updates.

<img width="1002" height="170" alt="image" src="https://github.com/user-attachments/assets/9a345cf4-29c2-48ad-8b8b-225fbd8a4957" />

In the script you can replace the string "InstalelrClean" in different setting setup  

#define ProgramName "InstallerCler"

and use {#ProgramName}